### PR TITLE
Centralmanager methods

### DIFF
--- a/iphone/Classes/TiBluetoothCentralManagerProxy.m
+++ b/iphone/Classes/TiBluetoothCentralManagerProxy.m
@@ -235,8 +235,7 @@
     
     NSMutableArray<TiBluetoothPeripheralProxy*> *result = [NSMutableArray array];
     
-    for (id peripheral in peripherals) {
-        ENSURE_TYPE(peripheral, CBPeripheral);
+    for (CBPeripheral *peripheral in peripherals) {
         [result addObject:[self peripheralProxyFromPeripheral:peripheral]];
     }
 

--- a/iphone/Classes/TiBluetoothCentralManagerProxy.m
+++ b/iphone/Classes/TiBluetoothCentralManagerProxy.m
@@ -136,6 +136,22 @@
     return NUMINTEGER([centralManager state]);
 }
 
+- (id)retrievePeripheralsWithIdentifiers:(id)args
+{
+    id identifiers = [args objectAtIndex:0];
+    ENSURE_TYPE_OR_NIL(identifiers, NSArray);
+    
+    return [self peripheralProxyArrayFromPeripheralArray:[centralManager retrievePeripheralsWithIdentifiers:[TiBluetoothUtils NSUUIDArrayFromStringArray:identifiers]]];
+}
+
+- (id)retrieveConnectedPeripheralsWithServices:(id)args
+{
+  id serviceUUIDs = [args objectAtIndex:0];
+  ENSURE_TYPE_OR_NIL(serviceUUIDs, NSArray);
+  
+  return [self peripheralProxyArrayFromPeripheralArray:[centralManager retrieveConnectedPeripheralsWithServices:[TiBluetoothUtils CBUUIDArrayFromStringArray:serviceUUIDs]]];
+}
+
 #pragma mark Delegates
 
 - (void)centralManager:(CBCentralManager *)central didConnectPeripheral:(CBPeripheral *)peripheral
@@ -208,6 +224,22 @@
         [[TiBluetoothPeripheralProvider sharedInstance] addPeripheral:result];
     }
     
+    return result;
+}
+
+- (NSArray<TiBluetoothPeripheralProxy *> *)peripheralProxyArrayFromPeripheralArray:(NSArray<CBPeripheral *> *)peripherals
+{
+    if (peripherals == nil) {
+        return nil;
+    }
+    
+    NSMutableArray<TiBluetoothPeripheralProxy*> *result = [NSMutableArray array];
+    
+    for (id peripheral in peripherals) {
+        ENSURE_TYPE(peripheral, CBPeripheral);
+        [result addObject:[self peripheralProxyFromPeripheral:peripheral]];
+    }
+
     return result;
 }
 

--- a/iphone/Classes/TiBluetoothCentralManagerProxy.m
+++ b/iphone/Classes/TiBluetoothCentralManagerProxy.m
@@ -73,7 +73,7 @@
         }
         
         if ([dict objectForKey:@"solicitedServiceUUIDs"] != nil) {
-            [options setObject:[TiBluetoothUtils UUIDArrayFromStringArray:[dict objectForKey:@"solicitedServiceUUIDs"]]
+            [options setObject:[TiBluetoothUtils CBUUIDArrayFromStringArray:[dict objectForKey:@"solicitedServiceUUIDs"]]
                         forKey:CBCentralManagerScanOptionSolicitedServiceUUIDsKey];
         }
     }

--- a/iphone/Classes/TiBluetoothPeripheralManagerProxy.m
+++ b/iphone/Classes/TiBluetoothPeripheralManagerProxy.m
@@ -79,7 +79,7 @@
         }
         
         if (serviceUUIDs != nil) {
-            [advertisementData setObject: [TiBluetoothUtils UUIDArrayFromStringArray:serviceUUIDs] forKey:CBAdvertisementDataServiceUUIDsKey];
+            [advertisementData setObject: [TiBluetoothUtils CBUUIDArrayFromStringArray:serviceUUIDs] forKey:CBAdvertisementDataServiceUUIDsKey];
         }
       
         [peripheralManager startAdvertising:advertisementData];

--- a/iphone/Classes/TiBluetoothPeripheralProxy.m
+++ b/iphone/Classes/TiBluetoothPeripheralProxy.m
@@ -60,7 +60,7 @@
 
 - (void)discoverServices:(id)args
 {
-    [_peripheral discoverServices:[TiBluetoothUtils UUIDArrayFromStringArray:args]];
+    [_peripheral discoverServices:[TiBluetoothUtils CBUUIDArrayFromStringArray:args]];
 }
 
 - (void)discoverIncludedServicesForService:(id)args
@@ -73,7 +73,7 @@
     ENSURE_TYPE(includedServices, NSArray);
     ENSURE_TYPE(service, TiBluetoothServiceProxy);
     
-    [_peripheral discoverIncludedServices:[TiBluetoothUtils UUIDArrayFromStringArray:includedServices]
+    [_peripheral discoverIncludedServices:[TiBluetoothUtils CBUUIDArrayFromStringArray:includedServices]
                                forService:[(TiBluetoothServiceProxy *)service service]];
 }
 
@@ -90,7 +90,7 @@
         ENSURE_TYPE_OR_NIL(characteristics, NSArray);
         ENSURE_TYPE(service, TiBluetoothServiceProxy);
 
-        [_peripheral discoverCharacteristics:[TiBluetoothUtils UUIDArrayFromStringArray:characteristics]
+        [_peripheral discoverCharacteristics:[TiBluetoothUtils CBUUIDArrayFromStringArray:characteristics]
                                   forService:[(TiBluetoothServiceProxy *)service service]];
     } else {
         ENSURE_SINGLE_ARG(args, NSDictionary);
@@ -101,7 +101,7 @@
         ENSURE_TYPE_OR_NIL(characteristics, NSArray);
         ENSURE_TYPE(service, TiBluetoothServiceProxy);
         
-        [_peripheral discoverCharacteristics:[TiBluetoothUtils UUIDArrayFromStringArray:characteristics]
+        [_peripheral discoverCharacteristics:[TiBluetoothUtils CBUUIDArrayFromStringArray:characteristics]
                                   forService:[(TiBluetoothServiceProxy *)service service]];
 
     }

--- a/iphone/Classes/TiBluetoothPeripheralProxy.m
+++ b/iphone/Classes/TiBluetoothPeripheralProxy.m
@@ -53,6 +53,11 @@
     return [self arrayFromServices:_peripheral.services];
 }
 
+- (id)identifier
+{
+    return _peripheral.identifier.UUIDString;
+}
+
 - (void)readRSSI:(id)unused
 {
     [_peripheral readRSSI];

--- a/iphone/Classes/TiBluetoothUtils.h
+++ b/iphone/Classes/TiBluetoothUtils.h
@@ -11,7 +11,8 @@
 
 }
 
-+ (NSArray<CBUUID *> *)UUIDArrayFromStringArray:(NSArray<id> *)array;
++ (NSArray<CBUUID *> *)CBUUIDArrayFromStringArray:(NSArray<id> *)array;
++ (NSArray<NSUUID *> *)NSUUIDArrayFromStringArray:(NSArray<id> *)array;
 + (NSArray<id> *)stringArrayFromUUIDArray:(NSArray<CBUUID *> *)array;
 
 @end

--- a/iphone/Classes/TiBluetoothUtils.m
+++ b/iphone/Classes/TiBluetoothUtils.m
@@ -10,7 +10,7 @@
 
 @implementation TiBluetoothUtils
 
-+ ( NSArray<CBUUID *> * _Nullable)UUIDArrayFromStringArray:(NSArray<id> *)array
++ ( NSArray<CBUUID *> * _Nullable)CBUUIDArrayFromStringArray:(NSArray<id> *)array
 {
     if (array == nil) {
         return nil;
@@ -21,6 +21,22 @@
     for (id uuid in array) {
         ENSURE_TYPE(uuid, NSString);
         [result addObject:[CBUUID UUIDWithString:[TiUtils stringValue:uuid]]];
+    }
+
+    return result;
+}
+
++ ( NSArray<NSUUID *> * _Nullable)NSUUIDArrayFromStringArray:(NSArray<id> *)array
+{
+    if (array == nil) {
+        return nil;
+    }
+    
+    NSMutableArray<NSUUID*> *result = [NSMutableArray array];
+    
+    for (id uuid in array) {
+        ENSURE_TYPE(uuid, NSString);
+        [result addObject:[[NSUUID alloc] initWithUUIDString:[TiUtils stringValue:uuid]]];
     }
 
     return result;

--- a/iphone/Classes/TiBluetoothUtils.m
+++ b/iphone/Classes/TiBluetoothUtils.m
@@ -26,7 +26,7 @@
     return result;
 }
 
-+ ( NSArray<NSUUID *> * _Nullable)NSUUIDArrayFromStringArray:(NSArray<id> *)array
++ ( NSArray<NSUUID *> * _Nullable)NSUUIDArrayFromStringArray:(NSArray<NSString *> *)array
 {
     if (array == nil) {
         return nil;
@@ -34,8 +34,7 @@
     
     NSMutableArray<NSUUID*> *result = [NSMutableArray array];
     
-    for (id uuid in array) {
-        ENSURE_TYPE(uuid, NSString);
+    for (NSString *uuid in array) {
         [result addObject:[[NSUUID alloc] initWithUUIDString:[TiUtils stringValue:uuid]]];
     }
 

--- a/iphone/manifest
+++ b/iphone/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 1.1.2
+version: 1.2.0
 apiversion: 2
 architectures: armv7 arm64 i386 x86_64
 description: ti.bluetooth


### PR DESCRIPTION
Example:
```
centralManager.retrievePeripheralsWithIdentifiers([connectedPeripheral.identifier]);
centralManager.retrieveConnectedPeripheralsWithServices([TARGET_SERVICE_UUID]);
```