### PR TITLE
Update tiapp.xml sample for iOS 13+ 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Add the following to your plist (only neccessary for iOS):
         </array>
         <key>NSBluetoothPeripheralUsageDescription</key>
         <string>Can we connect to Bluetooth devices?</string>
+	<!-- since iOS 13 -->
+	<key>NSBluetoothAlwaysUsageDescription</key>
+        <string>Bluetooth device communication.</string>
     </dict>
 </plist>
 ```

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Add the following to your plist (only neccessary for iOS):
         </array>
         <key>NSBluetoothPeripheralUsageDescription</key>
         <string>Can we connect to Bluetooth devices?</string>
-	<!-- since iOS 13 -->
-	<key>NSBluetoothAlwaysUsageDescription</key>
+        <!-- since iOS 13 -->
+        <key>NSBluetoothAlwaysUsageDescription</key>
         <string>Bluetooth device communication.</string>
     </dict>
 </plist>


### PR DESCRIPTION
Update tiapp.xml sample for iOS 13+ NSBluetoothAlwaysUsageDescription key requirement. 

Apps will crash without this new key now! 

(which took me far too long to find out what was causing it ;) )