### PR TITLE
fix: Remove a2dp from manifest

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 4.0.0
+version: 4.0.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: ti.bluetooth

--- a/android/timodule.xml
+++ b/android/timodule.xml
@@ -13,7 +13,6 @@
 					<intent-filter>
 						<action android:name="android.bluetooth.adapter.action.STATE_CHANGED"/>
 						<action android:name="android.bluetooth.device.action.BOND_STATE_CHANGED"/>
-						<action android:name="android.bluetooth.a2dp.profile.action.CONNECTION_STATE_CHANGED"/>
 					</intent-filter>
 				</receiver>
 			</application>


### PR DESCRIPTION
Forgot to make the PR for https://github.com/hansemannn/titanium-bluetooth/issues/48

Issue: App will freeze when Headset is connecting


* app closed (nothing in the background)
* disable bluetooth/gps
```
[DEBUG] TiBaseActivity: (main) [1967,2063] onBackPressed: exit
[DEBUG] Window: Window is closed normally.
[DEBUG] BluetoothAdapter: onBluetoothServiceDown: android.bluetooth.IBluetooth$Stub$Proxy@c43963d
```
* enabling bluetooth/gps
* headset is connected automatically
* opening my BT test app
```
[DEBUG] BluetoothAdapter: onBluetoothServiceUp: android.bluetooth.IBluetooth$Stub$Proxy@bbbe32
[DEBUG] AndroidRuntime: Shutting down VM
```
-> app won't start. timeout/crash:
```
BroadcastQueue: Timeout of broadcast BroadcastRecord{20cdeef u0 android.bluetooth.a2dp.profile.action.CONNECTION_STATE_CHANGED} - receiver=android.os.BinderProxy@935654a, started 60000ms ago
BroadcastQueue: Receiver during timeout of BroadcastRecord{20cdeef u0 android.bluetooth.a2dp.profile.action.CONNECTION_STATE_CHANGED} : ResolveInfo{1d4dcbb com.miga.tiscale/ti.bluetooth.ti.bluetooth.broadcastReceiver.TiBluetoohBroadcastReceiver m=0x108000}
BroadcastQueue: Background execution not allowed: receiving Intent { act=android.bluetooth.adapter.action.CONNECTION_STATE_CHANGED flg=0x4000010 (has extras) } to com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
```

Since most users use BLE for other reasons it is better to remove the intent-filter `<action android:name="android.bluetooth.a2dp.profile.action.CONNECTION_STATE_CHANGED"/>` to eliminate the issue.

A user could add that by hand when handling A2DP devices.